### PR TITLE
Change flake to flake8

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -14,7 +14,7 @@
 
 import setuptools
 
-TESTS_REQUIRES = ["pytest", "pytest-tornasync", "mypy"]
+TESTS_REQUIRES = ["pytest", "pytest-tornasync", "mypy", "flake8"]
 
 REQUIRES = [
     "certifi>=14.05.14",


### PR DESCRIPTION
2. Setup.py: Should be flake8, not flake. https://github.com/kubeflow/training-operator/blob/master/sdk/python/setup.py#L22
